### PR TITLE
Change timeout to interrupt processing message

### DIFF
--- a/run_config.json
+++ b/run_config.json
@@ -3,10 +3,10 @@
   "numConsensus": 100,
   "startingSeed": 0,
   "seedMultiplier": 100,
-  "numNodes": 27,
+  "numNodes": 16,
   "nodeProcessingRate": 3,
-  "switchProcessingRate": 9,
-  "baseTimeLimit": 10000,
-  "networkType": "FoldedClos",
+  "switchProcessingRate": -1,
+  "baseTimeLimit": 8,
+  "networkType": "Clique",
   "networkParameters": [5, 1, 0]
 }

--- a/run_config.json
+++ b/run_config.json
@@ -1,12 +1,12 @@
 {
   "numRuns": 1,
-  "numConsensus": 100,
+  "numConsensus": 200,
   "startingSeed": 0,
   "seedMultiplier": 100,
   "numNodes": 16,
   "nodeProcessingRate": 3,
   "switchProcessingRate": -1,
-  "baseTimeLimit": 8,
+  "baseTimeLimit": 6,
   "networkType": "Clique",
   "networkParameters": [5, 1, 0]
 }

--- a/src/main/java/simulation/Main.java
+++ b/src/main/java/simulation/Main.java
@@ -1,11 +1,11 @@
 package simulation;
 
 import com.google.gson.Gson;
+import simulation.io.IoInterface;
+import simulation.io.NoIo;
 import simulation.json.IBFTResultsJson;
 import simulation.json.QueueResultsJson;
 import simulation.json.RunConfigJson;
-import simulation.io.FileIo;
-import simulation.io.IoInterface;
 import simulation.network.entity.EndpointNode;
 import simulation.network.entity.Node;
 import simulation.network.entity.ibft.IBFTMessage;
@@ -56,7 +56,8 @@ public class Main {
         int startingSeed = runConfigJson.getStartingSeed();
         double validatorServiceRate = runConfigJson.getNodeProcessingRate();
 
-        IoInterface io = new FileIo("output.txt");
+//        IoInterface io = new FileIo("output.txt");
+        IoInterface io = new NoIo();
         IBFTStatistics ibftStats = null;
         QueueStatistics validatorQueueStats = null;
         List<QueueStatistics> switchStatistics = new ArrayList<>();

--- a/src/main/java/simulation/Main.java
+++ b/src/main/java/simulation/Main.java
@@ -1,11 +1,11 @@
 package simulation;
 
 import com.google.gson.Gson;
-import simulation.io.IoInterface;
-import simulation.io.NoIo;
 import simulation.json.IBFTResultsJson;
 import simulation.json.QueueResultsJson;
 import simulation.json.RunConfigJson;
+import simulation.io.FileIo;
+import simulation.io.IoInterface;
 import simulation.network.entity.EndpointNode;
 import simulation.network.entity.Node;
 import simulation.network.entity.ibft.IBFTMessage;
@@ -56,8 +56,7 @@ public class Main {
         int startingSeed = runConfigJson.getStartingSeed();
         double validatorServiceRate = runConfigJson.getNodeProcessingRate();
 
-//        IoInterface io = new FileIo("output.txt");
-        IoInterface io = new NoIo();
+        IoInterface io = new FileIo("output.txt");
         IBFTStatistics ibftStats = null;
         QueueStatistics validatorQueueStats = null;
         List<QueueStatistics> switchStatistics = new ArrayList<>();

--- a/src/main/java/simulation/Main.java
+++ b/src/main/java/simulation/Main.java
@@ -66,7 +66,7 @@ public class Main {
             List<IBFTNode> nodes = new ArrayList<>();
             Simulator<IBFTMessage> simulator = new Simulator<>();
             for (int j = 0; j < numNodes; j++) {
-                nodes.add(new IBFTNode("IBFT-" + j, j, timeLimit, simulator, numNodes, consensusLimit,
+                nodes.add(new IBFTNode("IBFT-" + j, j, timeLimit, consensusLimit, simulator, numNodes,
                         new ExponentialDistribution(validatorServiceRate)));
             }
             simulator.setNodes(nodes);

--- a/src/main/java/simulation/event/EventUtil.java
+++ b/src/main/java/simulation/event/EventUtil.java
@@ -8,9 +8,9 @@ import java.util.List;
 
 public class EventUtil {
 
-    public static <T> List<Event> convertPayloadsToQueueEvents(double time, Node<T> currentNode,
+    public static <T> List<NodeEvent<T>> convertPayloadsToQueueEvents(double time, Node<T> currentNode,
             List<? extends Payload<T>> payloads) {
-        List<Event> events = new ArrayList<>();
+        List<NodeEvent<T>> events = new ArrayList<>();
         for (Payload<T> payload : payloads) {
             events.add(new QueueEvent<>(time, currentNode.getNextNodeFor(payload), payload));
         }

--- a/src/main/java/simulation/event/InitializationEvent.java
+++ b/src/main/java/simulation/event/InitializationEvent.java
@@ -6,23 +6,20 @@ import simulation.network.entity.Payload;
 import java.util.ArrayList;
 import java.util.List;
 
-public class InitializationEvent<T> extends Event {
+public class InitializationEvent<T> extends NodeEvent<T> {
 
     public static final double START_TIME = 0;
 
-    private Node<T> node;
-
     public InitializationEvent(Node<T> node) {
-        super(START_TIME);
-        this.node = node;
+        super(START_TIME, node);
     }
 
     @Override
-    public List<Event> simulate() {
-        List<Event> eventList = new ArrayList<>();
-        List<Payload<T>> payloads = node.initializationPayloads();
+    public List<NodeEvent<T>> simulate() {
+        List<NodeEvent<T>> eventList = new ArrayList<>();
+        List<Payload<T>> payloads = getNode().initializationPayloads();
         for (Payload<T> payload : payloads) {
-            Node<T> nextHopNode = node.getNextNodeFor(payload);
+            Node<T> nextHopNode = getNode().getNextNodeFor(payload);
             eventList.add(new QueueEvent<>(START_TIME, nextHopNode, payload));
         }
         return eventList;
@@ -30,6 +27,6 @@ public class InitializationEvent<T> extends Event {
 
     @Override
     public String toString() {
-        return super.toString() + " (Initialization): " + node;
+        return super.toString() + " (Initialization): " + getNode();
     }
 }

--- a/src/main/java/simulation/event/NodeEvent.java
+++ b/src/main/java/simulation/event/NodeEvent.java
@@ -1,22 +1,29 @@
 package simulation.event;
 
-import simulation.util.Printable;
+import simulation.network.entity.Node;
 
 import java.util.List;
 
-public abstract class Event implements Comparable<Event>, Printable {
-    private double time;
+public abstract class NodeEvent<T> implements Comparable<NodeEvent<T>> {
 
-    public Event(double time) {
+    private double time;
+    private Node<T> node;
+
+    public NodeEvent(double time, Node<T> node) {
         this.time = time;
+        this.node = node;
     }
 
     public double getTime() {
         return time;
     }
 
+    public Node<T> getNode() {
+        return node;
+    }
+
     @Override
-    public int compareTo(Event e) {
+    public int compareTo(NodeEvent<T> e) {
         if (this.time > e.time) {
             return 1;
         } else if (this.time == e.time) {
@@ -31,10 +38,5 @@ public abstract class Event implements Comparable<Event>, Printable {
         return String.format("%.3f", time);
     }
 
-    public abstract List<Event> simulate();
-
-    @Override
-    public boolean toDisplay() {
-        return true;
-    }
+    public abstract List<NodeEvent<T>> simulate();
 }

--- a/src/main/java/simulation/event/PollQueueEvent.java
+++ b/src/main/java/simulation/event/PollQueueEvent.java
@@ -5,18 +5,17 @@ import simulation.network.entity.Payload;
 
 import java.util.List;
 
-public class PollQueueEvent<T> extends Event {
+public class PollQueueEvent<T> extends NodeEvent<T> {
 
-    private Node<T> node;
     private Payload<T> payload;
 
     public PollQueueEvent(double time, Node<T> node) {
-        super(time);
-        this.node = node;
+        super(time, node);
     }
 
     @Override
-    public List<Event> simulate() {
+    public List<NodeEvent<T>> simulate() {
+        Node<T> node = getNode();
         if (!node.isEmpty() && !node.isOccupiedAtTime(getTime())) {
             payload = node.popFromQueue(getTime());
             return List.of(new ProcessPayloadEvent<>(getTime(), node, payload));
@@ -27,6 +26,6 @@ public class PollQueueEvent<T> extends Event {
 
     @Override
     public String toString() {
-        return super.toString() + " (PollQueueEvent): Polling from " + node + " (" + payload + ")";
+        return super.toString() + " (PollQueueEvent): Polling from " + getNode() + " (" + payload + ")";
     }
 }

--- a/src/main/java/simulation/event/ProcessPayloadEvent.java
+++ b/src/main/java/simulation/event/ProcessPayloadEvent.java
@@ -9,25 +9,24 @@ import java.util.List;
 
 import static simulation.event.EventUtil.convertPayloadsToQueueEvents;
 
-public class ProcessPayloadEvent<T> extends Event {
+public class ProcessPayloadEvent<T> extends NodeEvent<T> {
 
-    private Node<T> node;
-    private Payload<T> payload;
+    private final Payload<T> payload;
     private double processingEndTime;
 
     public ProcessPayloadEvent(double time, Node<T> node, Payload<T> payload) {
-        super(time);
-        this.node = node;
+        super(time, node);
         this.payload = payload;
         this.processingEndTime = 0;
     }
 
     @Override
-    public List<Event> simulate() {
+    public List<NodeEvent<T>> simulate() {
+        Node<T> node = getNode();
         Pair<Double, List<Payload<T>>> durationPayloadsPair = node.processPayload(getTime(), payload);
         List<Payload<T>> processedPayloads = durationPayloadsPair.second();
         processingEndTime = getTime() + durationPayloadsPair.first();
-        List<Event> eventList =
+        List<NodeEvent<T>> eventList =
                 new ArrayList<>(convertPayloadsToQueueEvents(processingEndTime, node, processedPayloads));
         eventList.add(new PollQueueEvent<>(processingEndTime, node));
         return eventList;
@@ -36,6 +35,6 @@ public class ProcessPayloadEvent<T> extends Event {
     @Override
     public String toString() {
         return String.format("%s-%.3f (ProcessPayload): Processing payload at %s (%s)",
-                super.toString(), processingEndTime, node, payload);
+                super.toString(), processingEndTime, getNode(), payload);
     }
 }

--- a/src/main/java/simulation/event/QueueEvent.java
+++ b/src/main/java/simulation/event/QueueEvent.java
@@ -5,18 +5,17 @@ import simulation.network.entity.Payload;
 
 import java.util.List;
 
-public class QueueEvent<T> extends Event {
+public class QueueEvent<T> extends NodeEvent<T> {
 
-    private Node<T> node;
-    private Payload<T> payload;
+    private final Payload<T> payload;
     public QueueEvent(double time, Node<T> node, Payload<T> payload) {
-        super(time);
-        this.node = node;
+        super(time, node);
         this.payload = payload;
     }
 
     @Override
-    public List<Event> simulate() {
+    public List<NodeEvent<T>> simulate() {
+        Node<T> node = getNode();
         boolean isNodeEmpty = node.isEmpty();
         node.addToQueue(getTime(), payload);
         return isNodeEmpty ? List.of(new PollQueueEvent<>(getTime(), node)) : List.of();
@@ -24,6 +23,6 @@ public class QueueEvent<T> extends Event {
 
     @Override
     public String toString() {
-        return super.toString() + " (QueueEvent): payload queued at " + node + " (" + payload + ")";
+        return super.toString() + " (QueueEvent): payload queued at " + getNode() + " (" + payload + ")";
     }
 }

--- a/src/main/java/simulation/event/TimedEvent.java
+++ b/src/main/java/simulation/event/TimedEvent.java
@@ -26,9 +26,4 @@ public class TimedEvent<T> extends NodeEvent<T> {
     public String toString() {
         return super.toString() + " (Timed): Notifying " + node + " at " + getTime();
     }
-
-    @Override
-    public boolean toDisplay() {
-        return !node.isDone();
-    }
 }

--- a/src/main/java/simulation/event/TimedEvent.java
+++ b/src/main/java/simulation/event/TimedEvent.java
@@ -6,20 +6,20 @@ import java.util.List;
 
 import static simulation.event.EventUtil.convertPayloadsToQueueEvents;
 
-public class TimedEvent<T> extends Event {
+public class TimedEvent<T> extends NodeEvent<T> {
 
-    private TimedNode<T> node;
-    private T message;
+    private final int id;
+    private final TimedNode<T> node;
 
-    public TimedEvent(double time, TimedNode<T> node, T message) {
-        super(time);
+    public TimedEvent(double time, TimedNode<T> node, int id) {
+        super(time, node);
         this.node = node;
-        this.message = message;
+        this.id = id;
     }
 
     @Override
-    public List<Event> simulate() {
-        return convertPayloadsToQueueEvents(getTime(), node, node.notifyTime(getTime(), message));
+    public List<NodeEvent<T>> simulate() {
+        return convertPayloadsToQueueEvents(getTime(), node, node.notifyTime(id));
     }
 
     @Override

--- a/src/main/java/simulation/network/entity/Node.java
+++ b/src/main/java/simulation/network/entity/Node.java
@@ -27,9 +27,8 @@ public abstract class Node<T> {
     }
 
     public abstract List<Payload<T>> initializationPayloads();
-    public abstract boolean isDone();
     public abstract Node<T> getNextNodeFor(Payload<T> payload);
-
+    public abstract boolean isStillRequiredToRun();
     public String getName() {
         return name;
     }

--- a/src/main/java/simulation/network/entity/NodeTimerNotifier.java
+++ b/src/main/java/simulation/network/entity/NodeTimerNotifier.java
@@ -1,7 +1,0 @@
-package simulation.network.entity;
-
-public interface NodeTimerNotifier<T> {
-
-    void notifyAtTime(TimedNode<T> node, double time, T message);
-    double getTime();
-}

--- a/src/main/java/simulation/network/entity/TimedNode.java
+++ b/src/main/java/simulation/network/entity/TimedNode.java
@@ -4,9 +4,9 @@ import java.util.List;
 
 public abstract class TimedNode<T> extends EndpointNode<T> {
 
-    private final NodeTimerNotifier<T> timerNotifier;
+    private final TimerNotifier<T> timerNotifier;
 
-    public TimedNode(String name, NodeTimerNotifier<T> timerNotifier) {
+    public TimedNode(String name, TimerNotifier<T> timerNotifier) {
         super(name);
         this.timerNotifier = timerNotifier;
     }
@@ -15,17 +15,16 @@ public abstract class TimedNode<T> extends EndpointNode<T> {
         return timerNotifier.getTime();
     }
 
-    public void notifyAtTime(double time, T message) {
-        timerNotifier.notifyAtTime(this, time, message);
+    public void notifyAtTime(double time, int id) {
+        timerNotifier.notifyAtTime(this, time, id);
     }
 
     /**
      * Returns a list of payloads after notifying the node at the requested time.
      *
-     * @param time to be notified, determined by a previous {@code getNextNotificationTime} call.
-     * @param message to be attached with the notification for analysis.
+     * @param count uniquely identifies the notification.
      * @return List of payloads to be sent at the given time.
      */
-    public abstract List<Payload<T>> notifyTime(double time, T message);
+    public abstract List<Payload<T>> notifyTime(int count);
 
 }

--- a/src/main/java/simulation/network/entity/TimerNotifier.java
+++ b/src/main/java/simulation/network/entity/TimerNotifier.java
@@ -1,0 +1,7 @@
+package simulation.network.entity;
+
+public interface TimerNotifier<T> {
+
+    void notifyAtTime(TimedNode<T> node, double time, int id);
+    double getTime();
+}

--- a/src/main/java/simulation/network/router/Switch.java
+++ b/src/main/java/simulation/network/router/Switch.java
@@ -10,7 +10,6 @@ import simulation.util.rng.RandomNumberGenerator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 public class Switch<T> extends Node<T> {
@@ -77,6 +76,11 @@ public class Switch<T> extends Node<T> {
         return nextHopNodeOptions.get(randomIndex);
     }
 
+    @Override
+    public boolean isStillRequiredToRun() {
+        return true;
+    }
+
     public List<Switch<T>> getSwitchNeighbors() {
         return switchNeighbors;
     }
@@ -91,11 +95,6 @@ public class Switch<T> extends Node<T> {
     @Override
     public List<Payload<T>> initializationPayloads() {
         return List.of();
-    }
-
-    @Override
-    public boolean isDone() {
-        return false;
     }
 
     @Override

--- a/src/main/java/simulation/simulator/Simulator.java
+++ b/src/main/java/simulation/simulator/Simulator.java
@@ -1,23 +1,23 @@
 package simulation.simulator;
 
-import simulation.event.Event;
 import simulation.event.InitializationEvent;
+import simulation.event.NodeEvent;
 import simulation.event.TimedEvent;
-import simulation.network.entity.TimedNode;
 import simulation.network.entity.Node;
-import simulation.network.entity.NodeTimerNotifier;
+import simulation.network.entity.TimedNode;
+import simulation.network.entity.TimerNotifier;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 
-public class Simulator<T> implements NodeTimerNotifier<T> {
+public class Simulator<T> implements TimerNotifier<T> {
 
     private static final int SNAPSHOT_INTERVAL = 1000000;
     private static final double TIME_CUTOFF = 10000000; // for safety
 
-    private PriorityQueue<Event> eventQueue;
+    private PriorityQueue<NodeEvent<T>> eventQueue;
     private int roundCount;
     private List<Node<T>> nodes;
     private double currentTime;
@@ -72,8 +72,8 @@ public class Simulator<T> implements NodeTimerNotifier<T> {
     }
 
     @Override
-    public void notifyAtTime(TimedNode<T> node, double time, T message) {
-        eventQueue.add(new TimedEvent<T>(time, node, message));
+    public void notifyAtTime(TimedNode<T> node, double time, int count) {
+        eventQueue.add(new TimedEvent<T>(time, node, count));
     }
 
     @Override

--- a/src/main/java/simulation/util/Printable.java
+++ b/src/main/java/simulation/util/Printable.java
@@ -1,6 +1,0 @@
-package simulation.util;
-
-public interface Printable {
-
-    boolean toDisplay();
-}


### PR DESCRIPTION
Currently, a message being processed at time t1 ending at t2 where t1 occurs before timeout and t2 occurs after would still be considered a valid message processed. If this message results in a timer reset then a timeout does not occur. 

This change changes the logic by ensuring that messages being processed would timeout given short time windows before being fully processed should it take too long to process. This change matters for initially short time window tests. 

- Changed Event to NodeEvent to include knowledge of a Node
- Simplified timer procedure to use only a single unique integer as identification for timer
- Changed simulation logic such that nodes will keep running as normal nodes until the last node crosses the consensus limit amount before ending the simulation. This results in many nodes exceeding the required number of consensus instances required.
- Fixed an issue where the sync operation between IBFT nodes required another message to cause it to sync instead of running it immediately after receiving the sync message.
- Removed `Printable` interface as its original intention was to get rid of timeout events with high base time limits (for simulation where no round change occurs)